### PR TITLE
Discard selectorless brace-enclosed blocks.

### DIFF
--- a/lib/CSSHostRule.js
+++ b/lib/CSSHostRule.js
@@ -1,0 +1,37 @@
+//.CommonJS
+var CSSOM = {
+    CSSRule: require("./CSSRule").CSSRule
+};
+///CommonJS
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/shadow-dom/#host-at-rule
+ */
+CSSOM.CSSHostRule = function CSSHostRule() {
+    CSSOM.CSSRule.call(this);
+    this.cssRules = [];
+};
+
+CSSOM.CSSHostRule.prototype = new CSSOM.CSSRule();
+CSSOM.CSSHostRule.prototype.constructor = CSSOM.CSSHostRule;
+CSSOM.CSSHostRule.prototype.type = 1001;
+//FIXME
+//CSSOM.CSSHostRule.prototype.insertRule = CSSStyleSheet.prototype.insertRule;
+//CSSOM.CSSHostRule.prototype.deleteRule = CSSStyleSheet.prototype.deleteRule;
+
+Object.defineProperty(CSSOM.CSSHostRule.prototype, "cssText", {
+  get: function() {
+    var cssTexts = [];
+    for (var i=0, length=this.cssRules.length; i < length; i++) {
+      cssTexts.push(this.cssRules[i].cssText);
+    }
+    return "@host {" + cssTexts.join("") + "}";
+  }
+});
+
+
+//.CommonJS
+exports.CSSHostRule = CSSOM.CSSHostRule;
+///CommonJS

--- a/lib/CSSStyleSheet.js
+++ b/lib/CSSStyleSheet.js
@@ -1,7 +1,8 @@
 //.CommonJS
 var CSSOM = {
 	StyleSheet: require("./StyleSheet").StyleSheet,
-	CSSStyleRule: require("./CSSStyleRule").CSSStyleRule
+	CSSStyleRule: require("./CSSStyleRule").CSSStyleRule,
+	CSSRule: require("./CSSRule").CSSRule
 };
 ///CommonJS
 
@@ -74,15 +75,30 @@ CSSOM.CSSStyleSheet.prototype.toString = function() {
 	var result = "";
 	var rules = this.cssRules;
 	for (var i=0; i<rules.length; i++) {
-		if (rules[i].type === 1) {
+		if (rules[i].type === CSSOM.CSSRule.STYLE_RULE) { // STYLE_RULE
 			result += rules[i].selectorText + " {";
 			if (rules[i].style) {
 				result += rules[i].style.cssText;
 			}
-			while (i + 1 < rules.length && rules[i + 1].selectorText === rules[i].selectorText) {
+			while (i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.STYLE_RULE && rules[i + 1].selectorText === rules[i].selectorText) {
 				i += 1;
 				if (rules[i].style) {
 					result += " " + rules[i].style.cssText;
+				}
+			}
+			result += "}\n";
+		} else if (rules[i].type === CSSOM.CSSRule.FONT_FACE_RULE) {
+			result += "@font-face {";
+			if (rules[i].style) {
+				result += rules[i].style.cssText;
+			}
+			var fontFamily = rules[i].style.getPropertyValue('font-family');
+			while (fontFamily && i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.FONT_FACE_RULE && rules[i + 1].style.getPropertyValue('font-family') === fontFamily) {
+				i += 1;
+				if (rules[i].style) {
+					rules[i].style.removeProperty('font-family');
+					result += " " + rules[i].style.cssText;
+					rules[i].style.setProperty('font-family', fontFamily);
 				}
 			}
 			result += "}\n";

--- a/lib/CSSStyleSheet.js
+++ b/lib/CSSStyleSheet.js
@@ -74,7 +74,21 @@ CSSOM.CSSStyleSheet.prototype.toString = function() {
 	var result = "";
 	var rules = this.cssRules;
 	for (var i=0; i<rules.length; i++) {
-		result += rules[i].cssText + "\n";
+		if (rules[i].type === 1) {
+			result += rules[i].selectorText + " {";
+			if (rules[i].style) {
+				result += rules[i].style.cssText;
+			}
+			while (i + 1 < rules.length && rules[i + 1].selectorText === rules[i].selectorText) {
+				i += 1;
+				if (rules[i].style) {
+					result += " " + rules[i].style.cssText;
+				}
+			}
+			result += "}\n";
+		} else {
+			result += rules[i].cssText + "\n";
+		}
 	}
 	return result;
 };

--- a/lib/CSSStyleSheet.js
+++ b/lib/CSSStyleSheet.js
@@ -74,30 +74,42 @@ CSSOM.CSSStyleSheet.prototype.deleteRule = function(index) {
 CSSOM.CSSStyleSheet.prototype.toString = function() {
 	var result = "";
 	var rules = this.cssRules;
+
+	function serializeRuleBodyWithoutIsContinuation(cssRule) {
+		var isContinuation = cssRule.style.getPropertyValue('is-continuation');
+			result;
+		if (isContinuation) {
+			rules[i].style.removeProperty('is-continuation');
+		}
+		result = cssRule.style.cssText;
+		if (isContinuation) {
+			rules[i].style.setProperty('is-continuation', isContinuation);
+		}
+		return result;
+	}
+
 	for (var i=0; i<rules.length; i++) {
 		if (rules[i].type === CSSOM.CSSRule.STYLE_RULE) { // STYLE_RULE
 			result += rules[i].selectorText + " {";
 			if (rules[i].style) {
-				result += rules[i].style.cssText;
+				result += serializeRuleBodyWithoutIsContinuation(rules[i]);
 			}
-			while (i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.STYLE_RULE && rules[i + 1].selectorText === rules[i].selectorText) {
+			while (i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.STYLE_RULE && rules[i + 1].selectorText === rules[i].selectorText && rules[i + 1].style && rules[i + 1].style.getPropertyValue('is-continuation') === 'yes') {
 				i += 1;
-				if (rules[i].style) {
-					result += " " + rules[i].style.cssText;
-				}
+				result += " " + serializeRuleBodyWithoutIsContinuation(rules[i]);
 			}
 			result += "}\n";
 		} else if (rules[i].type === CSSOM.CSSRule.FONT_FACE_RULE) {
 			result += "@font-face {";
 			if (rules[i].style) {
-				result += rules[i].style.cssText;
+				result += serializeRuleBodyWithoutIsContinuation(rules[i]);
 			}
 			var fontFamily = rules[i].style.getPropertyValue('font-family');
-			while (fontFamily && i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.FONT_FACE_RULE && rules[i + 1].style.getPropertyValue('font-family') === fontFamily) {
+			while (fontFamily && i + 1 < rules.length && rules[i + 1].type === CSSOM.CSSRule.FONT_FACE_RULE && rules[i + 1].style && rules[i + 1].style.getPropertyValue('is-continuation') === 'yes' && rules[i + 1].style.getPropertyValue('font-family') === fontFamily) {
 				i += 1;
 				if (rules[i].style) {
 					rules[i].style.removeProperty('font-family');
-					result += " " + rules[i].style.cssText;
+					result += " " + serializeRuleBodyWithoutIsContinuation(rules[i]);
 					rules[i].style.setProperty('font-family', fontFamily);
 				}
 			}

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,6 +1,7 @@
 //.CommonJS
 var CSSOM = {
 	CSSStyleSheet: require("./CSSStyleSheet").CSSStyleSheet,
+	CSSRule: require("./CSSRule").CSSRule,
 	CSSStyleRule: require("./CSSStyleRule").CSSStyleRule,
 	CSSImportRule: require("./CSSImportRule").CSSImportRule,
 	CSSMediaRule: require("./CSSMediaRule").CSSMediaRule,
@@ -251,9 +252,17 @@ CSSOM.parse = function parse(token) {
 					if (styleRule.style.getPropertyValue(name)) {
 						styleRule.__ends = i;
 						currentScope.cssRules.push(styleRule);
-						styleRule = new CSSOM.CSSStyleRule;
-						styleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
-						styleRule.__starts = i;
+						var newStyleRule = new styleRule.constructor();
+						newStyleRule.__starts = i;
+                                                if (styleRule.type === CSSOM.CSSRule.STYLE_RULE) {
+							newStyleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
+						} else if (styleRule.type === CSSOM.CSSRule.FONT_FACE_RULE) {
+							var fontFamily = styleRule.style.getPropertyValue('font-family');
+							if (fontFamily) {
+								newStyleRule.style.setProperty('font-family', fontFamily);
+							}
+						}
+						styleRule = newStyleRule;
 					}
 					styleRule.style.setProperty(name, buffer.trim(), priority);
 					priority = "";

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -246,6 +246,15 @@ CSSOM.parse = function parse(token) {
 		case ";":
 			switch (state) {
 				case "value":
+					// Hack: Start a new CSSStyleRule if a property gets redefined.
+					// Temporary workaround until https://github.com/NV/CSSOM/issues/16 gets resolved
+					if (styleRule.style.getPropertyValue(name)) {
+						styleRule.__ends = i;
+						currentScope.cssRules.push(styleRule);
+						styleRule = new CSSOM.CSSStyleRule;
+						styleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
+						styleRule.__starts = i;
+					}
 					styleRule.style.setProperty(name, buffer.trim(), priority);
 					priority = "";
 					buffer = "";
@@ -272,6 +281,15 @@ CSSOM.parse = function parse(token) {
 		case "}":
 			switch (state) {
 				case "value":
+					// Hack: Start a new CSSStyleRule if a property gets redefined.
+					// Temporary workaround until https://github.com/NV/CSSOM/issues/16 gets resolved
+					if (styleRule.style.getPropertyValue(name)) {
+						styleRule.__ends = i;
+						currentScope.cssRules.push(styleRule);
+						styleRule = new CSSOM.CSSStyleRule;
+						styleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
+						styleRule.__starts = i;
+					}
 					styleRule.style.setProperty(name, buffer.trim(), priority);
 					priority = "";
 				case "before-name":

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -368,6 +368,7 @@ CSSOM.parse = function parse(token) {
 					break;
 				case "broken-brace":
 					state = "before-selector";
+					buffer = "";
 					break;
 			}
 			break;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -18,7 +18,6 @@ var CSSOM = {
  * @param {string} token
  */
 CSSOM.parse = function parse(token) {
-
 	var i = 0;
 
 	/**
@@ -274,8 +273,10 @@ CSSOM.parse = function parse(token) {
 						var newStyleRule = new styleRule.constructor();
 						newStyleRule.__starts = i;
 						if (styleRule.type === CSSOM.CSSRule.STYLE_RULE) {
+							newStyleRule.style.setProperty('is-continuation', 'yes');
 							newStyleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
 						} else if (styleRule.type === CSSOM.CSSRule.FONT_FACE_RULE) {
+							newStyleRule.style.setProperty('is-continuation', 'yes');
 							var fontFamily = styleRule.style.getPropertyValue('font-family');
 							if (fontFamily) {
 								newStyleRule.style.setProperty('font-family', fontFamily);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -83,10 +83,13 @@ CSSOM.parse = function parse(token) {
 
 		// String
 		case '"':
-			index = token.indexOf('"', i + 1) + 1;
-			if (!index) {
-				parseError('Unmatched "');
-			}
+			index = i + 1;
+			do {
+				index = token.indexOf('"', index) + 1;
+				if (!index) {
+					parseError('Unmatched "');
+				}
+			} while (token[index - 2] === '\\')
 			buffer += token.slice(i, index);
 			i = index - 1;
 			switch (state) {
@@ -100,10 +103,13 @@ CSSOM.parse = function parse(token) {
 			break;
 
 		case "'":
-			index = token.indexOf("'", i + 1) + 1;
-			if (!index) {
-				parseError("Unmatched '");
-			}
+			index = i + 1;
+			do {
+				index = token.indexOf("'", index) + 1;
+				if (!index) {
+					parseError("Unmatched '");
+				}
+			} while (token[index - 2] === '\\')
 			buffer += token.slice(i, index);
 			i = index - 1;
 			switch (state) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -267,6 +267,7 @@ CSSOM.parse = function parse(token) {
 				case "value":
 					// Hack: Start a new CSSStyleRule if a property gets redefined.
 					// Temporary workaround until https://github.com/NV/CSSOM/issues/16 gets resolved
+					// Remember to keep this block of code in sync with the equivalent hack 50 lines below.
 					if (styleRule.style.getPropertyValue(name)) {
 						styleRule.__ends = i;
 						currentScope.cssRules.push(styleRule);
@@ -312,12 +313,23 @@ CSSOM.parse = function parse(token) {
 				case "value":
 					// Hack: Start a new CSSStyleRule if a property gets redefined.
 					// Temporary workaround until https://github.com/NV/CSSOM/issues/16 gets resolved
+					// Remember to keep this block of code in sync with the equivalent hack 50 lines above.
 					if (styleRule.style.getPropertyValue(name)) {
 						styleRule.__ends = i;
 						currentScope.cssRules.push(styleRule);
-						styleRule = new CSSOM.CSSStyleRule;
-						styleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
-						styleRule.__starts = i;
+						var newStyleRule = new styleRule.constructor();
+						newStyleRule.__starts = i;
+						if (styleRule.type === CSSOM.CSSRule.STYLE_RULE) {
+							newStyleRule.style.setProperty('is-continuation', 'yes');
+							newStyleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
+						} else if (styleRule.type === CSSOM.CSSRule.FONT_FACE_RULE) {
+							newStyleRule.style.setProperty('is-continuation', 'yes');
+							var fontFamily = styleRule.style.getPropertyValue('font-family');
+							if (fontFamily) {
+								newStyleRule.style.setProperty('font-family', fontFamily);
+							}
+						}
+						styleRule = newStyleRule;
 					}
 					styleRule.style.setProperty(name, buffer.trim(), priority);
 					priority = "";

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@ var CSSOM = {
 	CSSStyleRule: require("./CSSStyleRule").CSSStyleRule,
 	CSSImportRule: require("./CSSImportRule").CSSImportRule,
 	CSSMediaRule: require("./CSSMediaRule").CSSMediaRule,
+    CSSHostRule: require("./CSSHostRule").CSSHostRule,
 	CSSFontFaceRule: require("./CSSFontFaceRule").CSSFontFaceRule,
 	CSSStyleDeclaration: require('./CSSStyleDeclaration').CSSStyleDeclaration,
 	CSSKeyframeRule: require('./CSSKeyframeRule').CSSKeyframeRule,
@@ -52,7 +53,7 @@ CSSOM.parse = function parse(token) {
 	// @type CSSMediaRule|CSSKeyframesRule
 	var parentRule;
 
-	var selector, name, value, priority="", styleRule, mediaRule, importRule, fontFaceRule, keyframesRule, keyframeRule;
+	var selector, name, value, priority="", styleRule, mediaRule, importRule, fontFaceRule, keyframesRule, keyframeRule, hostRule;
 
 	var atKeyframesRegExp = /@(-(?:\w+-)+)?keyframes/g;
 
@@ -150,6 +151,13 @@ CSSOM.parse = function parse(token) {
 				i += "media".length;
 				buffer = "";
 				break;
+            } else if (token.indexOf("@host", i) === i) {
+                state = "hostRule-begin";
+                i += "host".length;
+                hostRule = new CSSOM.CSSHostRule();
+                hostRule.__starts = i;
+                buffer = "";
+                break;
 			} else if (token.indexOf("@import", i) === i) {
 				state = "importRule-begin";
 				i += "import".length;
@@ -192,6 +200,11 @@ CSSOM.parse = function parse(token) {
 				mediaRule.parentStyleSheet = styleSheet;
 				buffer = "";
 				state = "before-selector";
+            } else if (state === "hostRule-begin") {
+                currentScope = parentRule = hostRule;
+                hostRule.parentStyleSheet = styleSheet;
+                buffer = "";
+                state = "before-selector";
 			} else if (state === "fontFaceRule-begin") {
 				if (parentRule) {
 					fontFaceRule.parentRule = parentRule;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -273,7 +273,7 @@ CSSOM.parse = function parse(token) {
 						currentScope.cssRules.push(styleRule);
 						var newStyleRule = new styleRule.constructor();
 						newStyleRule.__starts = i;
-                                                if (styleRule.type === CSSOM.CSSRule.STYLE_RULE) {
+						if (styleRule.type === CSSOM.CSSRule.STYLE_RULE) {
 							newStyleRule.selectorText = currentScope.cssRules[currentScope.cssRules.length - 1].selectorText;
 						} else if (styleRule.type === CSSOM.CSSRule.FONT_FACE_RULE) {
 							var fontFamily = styleRule.style.getPropertyValue('font-family');

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -227,6 +227,9 @@ CSSOM.parse = function parse(token) {
 				styleRule.__starts = i;
 				buffer = "";
 				state = "before-name";
+			} else if (state === "before-selector") {
+				// Empty selector. Gather the style up as usual, then discard.
+				state = "broken-brace";
 			}
 			break;
 
@@ -361,6 +364,9 @@ CSSOM.parse = function parse(token) {
 					currentScope = styleSheet;
 					parentRule = null;
 					buffer = "";
+					state = "before-selector";
+					break;
+				case "broken-brace":
 					state = "before-selector";
 					break;
 			}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,13 @@
 {
-	"name": "cssom",
-	"description": "CSS Object Model implementation and CSS parser",
+	"name": "cssom-papandreou",
+	"description": "CSS Object Model implementation and CSS parser (fork that hacks in support for multiple occurrences of the same CSS property in a rule)",
 	"keywords": ["CSS", "CSSOM", "parser", "styleSheet"],
 	"version": "0.2.4",
 	"homepage": "https://github.com/NV/CSSOM",
 	"author": "Nikita Vasilyev <me@elv1s.ru>",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/NV/CSSOM.git"
-	},
-	"bugs": {
-		"url": "https://github.com/NV/CSSOM/issues"
+		"url": "git://github.com/papandreou/CSSOM.git"
 	},
 	"directories": {
 		"lib": "./lib"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cssom-papandreou",
 	"description": "CSS Object Model implementation and CSS parser (fork that hacks in support for multiple occurrences of the same CSS property in a rule)",
 	"keywords": ["CSS", "CSSOM", "parser", "styleSheet"],
-	"version": "0.2.4",
+	"version": "0.2.4-patch1",
 	"homepage": "https://github.com/NV/CSSOM",
 	"author": "Nikita Vasilyev <me@elv1s.ru>",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.2.0"
   },
   "devDependencies": {
-    "jake": "0.2.x"
+    "jake": "8.0.12"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "parser",
     "styleSheet"
   ],
-  "version": "0.2.4-patch2",
+  "version": "0.2.4-patch3",
   "homepage": "https://github.com/NV/CSSOM",
   "author": "Nikita Vasilyev <me@elv1s.ru>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "parser",
     "styleSheet"
   ],
-  "version": "0.2.4-patch4",
+  "version": "0.2.4-patch5",
   "homepage": "https://github.com/NV/CSSOM",
   "author": "Nikita Vasilyev <me@elv1s.ru>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "parser",
     "styleSheet"
   ],
-  "version": "0.2.4-patch3",
+  "version": "0.2.4-patch4",
   "homepage": "https://github.com/NV/CSSOM",
   "author": "Nikita Vasilyev <me@elv1s.ru>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,31 +1,36 @@
 {
-	"name": "cssom-papandreou",
-	"description": "CSS Object Model implementation and CSS parser (fork that hacks in support for multiple occurrences of the same CSS property in a rule)",
-	"keywords": ["CSS", "CSSOM", "parser", "styleSheet"],
-	"version": "0.2.4-patch1",
-	"homepage": "https://github.com/NV/CSSOM",
-	"author": "Nikita Vasilyev <me@elv1s.ru>",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/papandreou/CSSOM.git"
-	},
-	"directories": {
-		"lib": "./lib"
-	},
-	"main": "./lib/index.js",
-	"engines": {
-		"node": ">=0.2.0"
-	},
-	"devDependencies": {
-		"jake": "0.2.x"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://creativecommons.org/licenses/MIT/"
-		}
-	],
-	"scripts": {
-		"prepublish": "jake lib/index.js"
-	}
+  "name": "cssom-papandreou",
+  "description": "CSS Object Model implementation and CSS parser (fork that hacks in support for multiple occurrences of the same CSS property in a rule)",
+  "keywords": [
+    "CSS",
+    "CSSOM",
+    "parser",
+    "styleSheet"
+  ],
+  "version": "0.2.4-patch2",
+  "homepage": "https://github.com/NV/CSSOM",
+  "author": "Nikita Vasilyev <me@elv1s.ru>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/papandreou/CSSOM.git"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "./lib/index.js",
+  "engines": {
+    "node": ">=0.2.0"
+  },
+  "devDependencies": {
+    "jake": "0.2.x"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://creativecommons.org/licenses/MIT/"
+    }
+  ],
+  "scripts": {
+    "prepublish": "jake lib/index.js"
+  }
 }

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -956,8 +956,29 @@ describe('parse', function() {
 		});
 	});
 
+	given('a{content:"\\""}', function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe('"\\""');
+	});
+
+	given("a{content:'\\''}", function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe("'\\''");
+	});
+
+	given('a{content:"abc\\"\\"d\\"ef"}', function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe('"abc\\"\\"d\\"ef"');
+	});
+
+	given("a{content:'abc\\'\\'d\\'ef'}", function(input) {
+		var parsed = CSSOM.parse(input);
+		expect(parsed.cssRules[0].style.content).toBe("'abc\\'\\'d\\'ef'");
+	});
+
 });
 });
+
 
 /**
  * Recursively remove all keys which start with '_', except "_vendorPrefix", which needs to be tested against.

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -938,7 +938,7 @@ var TESTS = [
 		})()
 	},
 	{
-		input: 'body {color:red;}{color: green;font-size: 13px;}',
+		input: 'body {color:red;}{color: green;font-size: 13px;}span{color:green;}',
 		result: (function() {
 			var result = {
 				cssRules: [
@@ -949,6 +949,17 @@ var TESTS = [
 							length: 1,
 							parentRule: "..",
 							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					},
+					{
+						selectorText: "span",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "green"
 						},
 						parentRule: null,
 						parentStyleSheet: "../.."

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -936,6 +936,63 @@ var TESTS = [
 			result.cssRules[0].cssRules[2].style.parentRule = result.cssRules[0].cssRules[2];
 			return result;
 		})()
+	},
+	{
+		input: 'body {color:red;}{color: green;font-size: 13px;}',
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: "body",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					}
+				],
+				parentStyleSheet: null
+			};
+			return result;
+		})()
+	},
+	{
+		input: 'body {color:red;}, *{color: green;font-size: 13px;}',
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: "body",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					},
+					{
+						parentRule: null,
+						parentStyleSheet: "../..",
+						selectorText: ", *",
+						style: {
+							0: "color",
+							1: "font-size",
+							length: 2,
+							parentRule: "..",
+							color: "green",
+							"font-size": "13px"
+						}
+					}
+				],
+				parentStyleSheet: null
+			};
+			return result;
+		})()
 	}
 ];
 


### PR DESCRIPTION
As agreed upon, this branches from v0.2.4-patch5.
