### PR TITLE
Fix for empty selector

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -378,6 +378,7 @@ CSSOM.parse = function parse(token) {
 					break;
 				case "broken-brace":
 					state = "before-selector";
+					buffer = "";
 					break;
 			}
 			break;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -223,6 +223,9 @@ CSSOM.parse = function parse(token) {
 				documentRule.parentStyleSheet = styleSheet;
 				buffer = "";
 				state = "before-selector";
+			} else if (state === "before-selector") {
+				// Empty selector. Gather the style up as usual, then discard.
+				state = "broken-brace";
 			}
 			break;
 
@@ -371,6 +374,9 @@ CSSOM.parse = function parse(token) {
 					currentScope = styleSheet;
 					parentRule = null;
 					buffer = "";
+					state = "before-selector";
+					break;
+				case "broken-brace":
 					state = "before-selector";
 					break;
 			}

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -1028,6 +1028,63 @@ var TESTS = [
 
 			return result;
 		})()
+	},
+	{
+		input: 'body {color:red;}{color: green;font-size: 13px;}',
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: "body",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					}
+				],
+				parentStyleSheet: null
+			};
+			return result;
+		})()
+	},
+	{
+		input: 'body {color:red;}, *{color: green;font-size: 13px;}',
+		result: (function() {
+			var result = {
+				cssRules: [
+					{
+						selectorText: "body",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					},
+					{
+						parentRule: null,
+						parentStyleSheet: "../..",
+						selectorText: ", *",
+						style: {
+							0: "color",
+							1: "font-size",
+							length: 2,
+							parentRule: "..",
+							color: "green",
+							"font-size": "13px"
+						}
+					}
+				],
+				parentStyleSheet: null
+			};
+			return result;
+		})()
 	}
 ];
 

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -1030,7 +1030,7 @@ var TESTS = [
 		})()
 	},
 	{
-		input: 'body {color:red;}{color: green;font-size: 13px;}',
+		input: 'body {color:red;}{color: green;font-size: 13px;}span{color:green;}',
 		result: (function() {
 			var result = {
 				cssRules: [
@@ -1041,6 +1041,17 @@ var TESTS = [
 							length: 1,
 							parentRule: "..",
 							color: "red"
+						},
+						parentRule: null,
+						parentStyleSheet: "../.."
+					},
+					{
+						selectorText: "span",
+						style: {
+							0: "color",
+							length: 1,
+							parentRule: "..",
+							color: "green"
 						},
 						parentRule: null,
 						parentStyleSheet: "../.."


### PR DESCRIPTION
I've updated my patch for empty selectors (i.e. this case: `.classname { color: black; } { /* no selector */ color: red; }`) to work with v0.3.0. It was fairly painless, and passes the included tests without issue.
